### PR TITLE
command: depuplicate dependency list

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,4 +36,5 @@ require (
 	gopkg.in/toast.v1 v1.0.0-20180812000517-0a84660828b2 // indirect
 	gopkg.in/yaml.v1 v1.0.0-20140924161607-9f9df34309c0
 	gopkg.in/yaml.v2 v2.2.4
+	github.com/elliotchance/orderedmap v1.2.1
 )

--- a/go.sum
+++ b/go.sum
@@ -8,12 +8,15 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1 h1:q763qf9huN11kDQavWs
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/daaku/go.zipexe v0.0.0-20150329023125-a5fe2436ffcb h1:tUf55Po0vzOendQ7NWytcdK0VuzQmfAgvGBUOQvN0WA=
 github.com/daaku/go.zipexe v0.0.0-20150329023125-a5fe2436ffcb/go.mod h1:U0vRfAucUOohvdCxt5MWLF+TePIL0xbCkbKIiV8TQCE=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/desertbit/glue v0.0.0-20171018142742-09c14070c2b1 h1:lBWvZFaEPbocLCYSQhVj2lGin8AFQB3HT64taOIf5Vg=
 github.com/desertbit/glue v0.0.0-20171018142742-09c14070c2b1/go.mod h1:GmhZxaat6anpeRZmbGAvasJMoxyJmzIjQtkNfn1vSEo=
 github.com/dreadl0ck/readline v0.0.0-20160726135117-62c6fe619375 h1:TGqBUJCmNpKH7zKEQwT250j7Q9XehgirWjwtJX7WDz4=
 github.com/dreadl0ck/readline v0.0.0-20160726135117-62c6fe619375/go.mod h1:aPoBKlRY5R1G+VNa3P1Wjwh3C9SSRcOIp7+DXKh2PYA=
+github.com/elliotchance/orderedmap v1.2.1 h1:GtjbXT+bKnHtYZIDab/ns5AThDXQroKYaMWd+Ak7mvk=
+github.com/elliotchance/orderedmap v1.2.1/go.mod h1:8hdSl6jmveQw8ScByd3AaNHNk51RhbTazdqtTty+NFw=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/gen2brain/beeep v0.0.0-20190719094215-ece0cb67ca77 h1:bvjWrvlA7ddo8+E8X5D+m5jg0GkwTeG6eRJGb6f/rRE=
@@ -62,9 +65,11 @@ github.com/smartystreets/assertions v1.0.1 h1:voD4ITNjPL5jjBfgR/r8fPIIBrliWrWHei
 github.com/smartystreets/assertions v1.0.1/go.mod h1:kHHU4qYBaI3q23Pp3VPrmWhuIUrLW/7eUrw0BU5VaoM=
 github.com/smartystreets/goconvey v1.6.3 h1:QdmJJYlDQhMDFrFP8IvVnx66D8mCbaQM4TsxKf7BXzo=
 github.com/smartystreets/goconvey v1.6.3/go.mod h1:XDJAKZRPZ1CvBcN2aX5YOUTYGHki24fSF0Iv48Ibg0s=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/tadvi/systray v0.0.0-20190226123456-11a2b8fa57af h1:6yITBqGTE2lEeTPG04SN9W+iWHCRyHqlVYILiSXziwk=
 github.com/tadvi/systray v0.0.0-20190226123456-11a2b8fa57af/go.mod h1:4F09kP5F+am0jAwlQLddpoMDM+iewkxxt6nxUQ5nq5o=
 github.com/x-cray/logrus-prefixed-formatter v0.5.2 h1:00txxvfBM9muc0jiLIEAkAcIMJzfthRT6usrui8uGmg=
@@ -94,5 +99,6 @@ gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkep
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v1 v1.0.0-20140924161607-9f9df34309c0 h1:POO/ycCATvegFmVuPpQzZFJ+pGZeX22Ufu6fibxDVjU=
 gopkg.in/yaml.v1 v1.0.0-20140924161607-9f9df34309c0/go.mod h1:WDnlLJ4WF5VGsH/HVa3CI79GS0ol3YnhVnKP89i0kNg=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/utils.go
+++ b/utils.go
@@ -39,6 +39,7 @@ import (
 
 	yaml "gopkg.in/yaml.v2"
 
+	"github.com/elliotchance/orderedmap"
 	"github.com/gen2brain/beeep"
 	"github.com/mgutz/ansi"
 )
@@ -624,4 +625,16 @@ func dumpYAML(i interface{}) {
 	}
 
 	fmt.Println(string(out))
+}
+
+// remove duplicates element keeping the left-most ones
+func stripArrayRight(array []string) (strip []string) {
+	var stripMap = orderedmap.NewOrderedMap()
+	for _, element := range array {
+		if _, ok := stripMap.Get(element); !ok {
+			stripMap.Set(element, nil)
+			strip = append(strip, element)
+		}
+	}
+	return
 }


### PR DESCRIPTION
This commit basically introduces two changes:

- the command.execDependecies call is no more spawning commandsi only
  for direct dependencies of the explicitely called command,
  but it's building a deduplicated deep-dependencies list beforehand,
  in order to execute both indirect (first) and direct dependencies
  in a single shot;
- the command.Run call has been splitted so that the standard and
  old-fashioned call is only handling async and dependencies, while
  the new command.AtomicRun is taking care of all the rest, excluding
  dependencies management. Obviously, the command.Run is internally
  calling the command.AtomicRun. The whole code base is still relying on the
  standard command.Run, while the command.AtomicRun is being used within
  the command.execDependencies to support deduplication and disable
  recursive dependencies resolving for each sub-dependency.